### PR TITLE
Remove completed field on review model, making reviews always editable

### DIFF
--- a/backend/src/models/ReviewModel.ts
+++ b/backend/src/models/ReviewModel.ts
@@ -8,7 +8,6 @@ type Review = {
   application: Types.ObjectId;
   interview?: Types.ObjectId;
   reviewerEmail?: string;
-  completed: boolean;
   fields: Record<string, string | number | boolean>;
 };
 
@@ -34,10 +33,6 @@ const ReviewSchema = new Schema<Review>({
     index: true,
     // Not required, because reviews are created without an owner when they
     // are going to be manually assigned.
-  },
-  completed: {
-    type: Boolean,
-    required: true,
   },
   fields: {
     type: Map,

--- a/backend/src/models/StageModel.ts
+++ b/backend/src/models/StageModel.ts
@@ -8,7 +8,7 @@ type FormField = {
   allowOther: boolean;
   label: string;
   description: string;
-  weight?: number
+  weight?: number;
 };
 
 type Stage = {

--- a/backend/src/services/ProgressService.ts
+++ b/backend/src/services/ProgressService.ts
@@ -41,14 +41,6 @@ class ProgressService {
       return `Cannot advance; application is already ${progress.state}`;
     }
 
-    const currentStage = await StageService.getByPipelineAndIndex(pipeline, progress.stageIndex);
-    if (currentStage !== null) {
-      const reviews = await ReviewService.getByStageAndApplication(currentStage._id, application);
-      if (reviews.some((review) => !review.completed)) {
-        return `At least one review for the preceding stage (${progress.stageIndex}) is incomplete`;
-      }
-    }
-
     const nextIndex = progress.stageIndex + 1;
     const nextStage = await StageService.getByPipelineAndIndex(pipeline, nextIndex);
     if (nextStage === null) {

--- a/backend/src/services/ReviewService.ts
+++ b/backend/src/services/ReviewService.ts
@@ -19,7 +19,6 @@ class ReviewService {
     const review = await new ReviewModel({
       stage,
       application,
-      completed: false,
       fields: {},
     }).save();
 
@@ -75,10 +74,6 @@ class ReviewService {
     const existing = await ReviewModel.findById(review._id);
     if (existing === null) {
       return `No review with id: ${review._id}`;
-    }
-
-    if (existing.completed) {
-      return `Cannot update completed review: ${review._id}`;
     }
 
     // TODO: enforce that only the assigned reviewer can change fields
@@ -181,7 +176,6 @@ class ReviewService {
       stage: review.stage.toJSON(),
       application: review.application.toJSON(),
       reviewerEmail: review.reviewerEmail,
-      completed: review.completed,
       fields: review.fields,
     };
   }

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -47,7 +47,6 @@ export interface Review {
   stage: string;
   application: string;
   reviewerEmail?: string;
-  completed: boolean;
   fields: Record<string, string | number | boolean>;
 }
 

--- a/frontend/src/pages/EditReview.tsx
+++ b/frontend/src/pages/EditReview.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useMemo, useState } from "react";
+import React, { useContext, useEffect, useMemo } from "react";
 import { Button, Form } from "react-bootstrap";
 import { useParams, useLocation } from "react-router-dom";
 
@@ -9,14 +9,13 @@ import ApplicationView from "../views/ApplicationView";
 
 export function ReviewView({ id, showApplication }: { id: string; showApplication: boolean }) {
   const [review, setReview, { getField, setField }] = useStateHelper<Review>();
-  const [reviewFinished, setReviewFinished] = useState(true);
   const [stage, setStage] = useStateHelper<Stage>();
   const { alerts, addAlert } = useAlerts();
   const location = useLocation();
   const { user } = useContext(GlobalContext);
 
   const editable = useMemo(
-    () => !!(user && review && user.email === review.reviewerEmail && !review.completed),
+    () => !!(user && review && user.email === review.reviewerEmail),
     [user, review]
   );
 
@@ -46,7 +45,7 @@ export function ReviewView({ id, showApplication }: { id: string; showApplicatio
     }
 
     api
-      .updateReview({ ...review, completed: reviewFinished })
+      .updateReview(review)
       .then(setReview)
       .then(() => addAlert("Review saved.", "success"))
       .catch(addAlert);
@@ -142,18 +141,9 @@ export function ReviewView({ id, showApplication }: { id: string; showApplicatio
             );
           })}
         {editable && (
-          <>
-            <Form.Check
-              label="I am finished with this review"
-              checked={reviewFinished}
-              onChange={(e) => setReviewFinished(e.target.checked)}
-            />
-            <Form.Text>Leave this unchecked if you want to save a draft</Form.Text>
-            <br />
-            <Button type="submit" variant="success">
-              Save
-            </Button>
-          </>
+          <Button type="submit" variant="success">
+            Save
+          </Button>
         )}
         {alerts}
       </Form>

--- a/frontend/src/views/ReviewsView.tsx
+++ b/frontend/src/views/ReviewsView.tsx
@@ -90,27 +90,28 @@ export default function ReviewsView({
       .getFilteredReviews(filter)
       .then((newReviews) =>
         setReviews(
-          newReviews.slice().sort(
-            makeComparator((r) =>
-              homepage
-                ? [
-                    // eslint-disable-next-line no-nested-ternary
-                    r.completed ? 2 : Object.entries(r.fields).length > 0 ? 1 : 0,
-                    r.stage.name,
-                    r.application.gradQuarter,
-                    r.application.name,
-                    r.reviewerEmail || "",
-                    r._id,
-                  ]
-                : [
-                    r.stage.name,
-                    r.application.gradQuarter,
-                    r.application.name,
-                    r.reviewerEmail || "",
-                    r._id,
-                  ]
+          newReviews
+            .slice()
+            .sort(
+              makeComparator((r) =>
+                homepage
+                  ? [
+                      Object.entries(r.fields).length > 0 ? 1 : 0,
+                      r.stage.name,
+                      r.application.gradQuarter,
+                      r.application.name,
+                      r.reviewerEmail || "",
+                      r._id,
+                    ]
+                  : [
+                      r.stage.name,
+                      r.application.gradQuarter,
+                      r.application.name,
+                      r.reviewerEmail || "",
+                      r._id,
+                    ]
+              )
             )
-          )
         )
       )
       .catch(addAlert);
@@ -137,12 +138,7 @@ export default function ReviewsView({
           </thead>
           <tbody>
             {reviews.map((review) => {
-              let status: string;
-              if (review.completed) {
-                status = "complete";
-              } else {
-                status = Object.keys(review.fields).length > 0 ? "draft" : "blank";
-              }
+              const status = Object.keys(review.fields).length > 0 ? "complete" : "blank";
               const pastReviewers = Object.entries(
                 reviews
                   .filter((r) => review.application._id === r.application._id)
@@ -182,7 +178,7 @@ export default function ReviewsView({
                   <td>{status}</td>
                   {showReassign && (
                     <td>
-                      {!review.completed && <ManualAssign id={review._id} addAlert={addAlert} />}
+                      <ManualAssign id={review._id} addAlert={addAlert} />
                     </td>
                   )}
                 </tr>

--- a/frontend/src/views/StageApplicationsView.tsx
+++ b/frontend/src/views/StageApplicationsView.tsx
@@ -94,29 +94,29 @@ export default function StageApplicationsView({ stageId }: { stageId: string }) 
     grouped[appId][1].push(review);
   });
 
+  const isComplete = (review: PopulatedReview) => Object.keys(review.fields).length !== 0;
+
   let scoreKeys: string[] = [];
-  reviews
-    .filter((r) => r.completed)
-    .forEach((review) => {
-      const currentScoreKeys = Object.keys(review.fields)
-        .filter((k) => SCORE_REGEX.test(k))
-        .sort();
-      if (scoreKeys.length === 0) {
-        scoreKeys = currentScoreKeys;
-      } else if (JSON.stringify(scoreKeys) !== JSON.stringify(currentScoreKeys)) {
-        // ^^^ crummy way of checking array equality
-        addScoreAlert(
-          `Mismatched score fields - score calculation is probably incorrect! ${JSON.stringify(
-            scoreKeys
-          )}, ${JSON.stringify(currentScoreKeys)}`
-        );
-      }
-    });
+  reviews.filter(isComplete).forEach((review) => {
+    const currentScoreKeys = Object.keys(review.fields)
+      .filter((k) => SCORE_REGEX.test(k))
+      .sort();
+    if (scoreKeys.length === 0) {
+      scoreKeys = currentScoreKeys;
+    } else if (JSON.stringify(scoreKeys) !== JSON.stringify(currentScoreKeys)) {
+      // ^^^ crummy way of checking array equality
+      addScoreAlert(
+        `Mismatched score fields - score calculation is probably incorrect! ${JSON.stringify(
+          scoreKeys
+        )}, ${JSON.stringify(currentScoreKeys)}`
+      );
+    }
+  });
 
   const withScores = Object.values(grouped).map(([app, appReviews]) => {
     const avgScore =
       appReviews
-        .filter((r) => r.completed)
+        .filter(isComplete)
         .map((review) =>
           scoreKeys
             .map((scoreKey) => {
@@ -176,7 +176,7 @@ export default function StageApplicationsView({ stageId }: { stageId: string }) 
           </thead>
           <tbody>
             {withScores.map(([app, appReviews, score], i) => {
-              const incompleteCount = appReviews.filter((r) => !r.completed).length;
+              const incompleteCount = appReviews.filter((r) => !isComplete(r)).length;
               const allComplete = incompleteCount === 0;
 
               const progress: Progress | undefined = progressesByApplication[app._id];
@@ -221,7 +221,7 @@ export default function StageApplicationsView({ stageId }: { stageId: string }) 
                   )}`}</td>
                   <td>{allComplete ? "all completed" : `${incompleteCount} incomplete`}</td>
                   <td>
-                    {pendingAtThisStage && allComplete ? (
+                    {pendingAtThisStage ? (
                       <>
                         {selectedAction === "advance" && (
                           <AdvanceButton
@@ -248,7 +248,7 @@ export default function StageApplicationsView({ stageId }: { stageId: string }) 
                     {appReviews.map((r) => (
                       <p key={r._id}>
                         {`${r.reviewerEmail || "(no reviewer assigned)"}${
-                          r.completed ? "" : " (incomplete)"
+                          isComplete(r) ? "" : " (incomplete)"
                         }: ${JSON.stringify(
                           Object.fromEntries(
                             Object.entries(r.fields)
@@ -263,7 +263,7 @@ export default function StageApplicationsView({ stageId }: { stageId: string }) 
                     {appReviews.map((r) => (
                       <p key={r._id}>
                         {`${r.reviewerEmail || "(no reviewer assigned)"}${
-                          r.completed ? "" : " (incomplete)"
+                          isComplete(r) ? "" : " (incomplete)"
                         }: ${JSON.stringify(
                           Object.fromEntries(
                             Object.entries(r.fields)


### PR DESCRIPTION
- Removed `completed` field on the review model
- Removed "save as draft" functionality, which no one was really using anyway
- Made reviews always editable, even after submission, to reduce maintenance load on VP Tech when someone submits a review then wants to edit it
- Changed UI logic to consider a review "complete" when at least 1 field has been submitted - but it can still be edited later