### PR TITLE
Bulk advance/reject applications

### DIFF
--- a/backend/src/cakes.ts
+++ b/backend/src/cakes.ts
@@ -1,4 +1,4 @@
-import { Infer, bake, number, string } from "caketype";
+import { Infer, array, bake, number, string } from "caketype";
 
 const LogInRequest = bake({
   email: string,
@@ -32,10 +32,16 @@ const CreatePipelineRequest = bake({
   stages: number,
 });
 
+const BulkAdvanceOrRejectRequest = bake({
+  pipelineId: string,
+  applicationIds: array(string),
+});
+
 export {
   LogInRequest,
   CreateUserRequest,
   ResetPasswordRequest,
   RequestPasswordResetRequest,
   CreatePipelineRequest,
+  BulkAdvanceOrRejectRequest,
 };

--- a/backend/src/models/StageModel.ts
+++ b/backend/src/models/StageModel.ts
@@ -8,7 +8,7 @@ type FormField = {
   allowOther: boolean;
   label: string;
   description: string;
-  weight?: number
+  weight?: number;
 };
 
 type Stage = {

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -33,6 +33,11 @@ interface CreatePipelineRequest {
   stages: number;
 }
 
+export type BulkAdvanceOrRejectResponse = Record<
+  string,
+  { success: true; value: Progress } | { success: false; value: string }
+>;
+
 interface FormField {
   type: "string" | "number" | "boolean";
   choices: (string | number | boolean)[];
@@ -203,12 +208,18 @@ class Api {
     return (await this.put(`/api/stage/${request._id}`, request)).json();
   }
 
-  async advanceApplication(progressId: string): Promise<Progress> {
-    return (await this.post(`/api/progress/${progressId}/advance`, undefined)).json();
+  async bulkAdvanceApplications(
+    pipelineId: string,
+    applicationIds: string[]
+  ): Promise<BulkAdvanceOrRejectResponse> {
+    return (await this.post("/api/progress/bulk_advance", { pipelineId, applicationIds })).json();
   }
 
-  async rejectApplication(progressId: string): Promise<Progress> {
-    return (await this.post(`/api/progress/${progressId}/reject`, undefined)).json();
+  async bulkRejectApplications(
+    pipelineId: string,
+    applicationIds: string[]
+  ): Promise<BulkAdvanceOrRejectResponse> {
+    return (await this.post("/api/progress/bulk_reject", { pipelineId, applicationIds })).json();
   }
 
   private async get(url: string, headers: Record<string, string> = {}): Promise<Response> {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,0 +1,5 @@
+/* For the bulk accept/reject checkboxes in the applicants table */
+.form-check-input {
+  width: 1.5em;
+  height: 1.5em;
+}


### PR DESCRIPTION
Replaced the individual accept/reject functionality with bulk accept/reject. This way, the user can select the checkboxes of every applicant to accept/reject, then accept/reject them all at once, and not have to wait for the API response for each applicant. This is useful because we get hundreds of applicants each year.

Screenshot:
![Screenshot from 2025-06-28 15-53-23](https://github.com/user-attachments/assets/deff9428-3436-4b82-af64-bb42dea2996e)
