### PR TITLE
Add option to go to next review after saving a review

### DIFF
--- a/backend/src/routes/review.ts
+++ b/backend/src/routes/review.ts
@@ -21,6 +21,18 @@ router.get(
 );
 
 router.get(
+  "/next",
+  authWrapper(async (user) => {
+    const result = await ReviewService.getNextReviewForUser(user.email);
+
+    return {
+      status: 200,
+      json: result ? ReviewService.serialize(result) : null,
+    };
+  }),
+);
+
+router.get(
   "/:reviewId",
   authWrapper(async (_user, req) => {
     const result = await ReviewService.getById(req.params.reviewId);

--- a/backend/src/services/ReviewService.ts
+++ b/backend/src/services/ReviewService.ts
@@ -164,6 +164,17 @@ class ReviewService {
     return results;
   }
 
+  async getNextReviewForUser(userEmail: string): Promise<ReviewDocument | null> {
+    const result = await ReviewModel.findOne({
+      // Find a review with no fields filled in
+      $expr: {
+        $eq: [{ $size: { $objectToArray: "$fields" } }, 0],
+      },
+      reviewerEmail: userEmail,
+    });
+    return result;
+  }
+
   serialize(review: ReviewDocument) {
     return {
       _id: review._id.toHexString(),

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -157,6 +157,10 @@ class Api {
     return (await this.get(`/api/review?${new URLSearchParams(Object.entries(filter))}`)).json();
   }
 
+  async getNextReview(): Promise<PopulatedReview | null> {
+    return (await this.get("/api/review/next")).json();
+  }
+
   async autoAssignReview(id: string): Promise<Review> {
     return (await this.post(`/api/review/${id}/auto-assign`, undefined)).json();
   }


### PR DESCRIPTION
As discussed, this is a convenience for reviewers to easily go to their next review without having to go back to the homepage.

I added a modal (just using the React Bootstrap `Modal` component for now) that either links to the next review, if there is one, or tells you you've finished all your reviews. This modal is displayed after saving a review.

<img width="1849" height="1016" alt="Screenshot from 2025-08-12 22-31-51" src="https://github.com/user-attachments/assets/06d7d020-1da9-4571-9468-e375f7804a54" />
<img width="1849" height="1016" alt="Screenshot from 2025-08-12 22-35-04" src="https://github.com/user-attachments/assets/fdfc155d-3e38-4175-89c4-8d30ddc066c8" />
