### PR TITLE
Disable assignment emails close to deadline, replace president email, move to environment variables

### DIFF
--- a/backend/src/env.ts
+++ b/backend/src/env.ts
@@ -20,6 +20,8 @@ function getEnv<T>(key: string, defaultValue: T, parser?: (fromEnv: string) => T
 
 const NODE_ENV = getEnv("NODE_ENV", "development");
 const ADMIN_EMAIL = getEnv("ADMIN_EMAIL", "tse@ucsd.edu");
+const applicationDeadlineString = getEnv("APPLICATION_DEADLINE", "");
+const APPLICATION_DEADLINE = applicationDeadlineString ? new Date(applicationDeadlineString) : null;
 
 // To configure these variables, use a .env file during development, or use
 // environment variables in production.
@@ -90,6 +92,18 @@ const env = {
     "https://raw.githubusercontent.com/TritonSE/TSE-Technical-Interview-Template/main/README.md",
   ),
 
+  /**
+   * Deadline to submit applications.
+   */
+
+  APPLICATION_DEADLINE,
+
+  /**
+   * How many hours before the deadline to start disabling reviewer assignment emails
+   * Default to 1 day
+   */
+  DISABLE_ASSIGNMENT_EMAILS_HOURS: parseInt(getEnv("DISABLE_ASSIGNMENT_EMAILS_HOURS", "24")),
+
   // Loaded from environment variables.
   NODE_ENV,
   PORT: getEnv("PORT", 8000, parseInt),
@@ -98,6 +112,10 @@ const env = {
 if (env.EMAIL_ENABLED && !(env.EMAIL_USERNAME && env.EMAIL_PASSWORD && env.EMAIL_HOST)) {
   console.error("Email configuration incomplete. Disabling email.");
   env.EMAIL_ENABLED = false;
+}
+
+if (!env.APPLICATION_DEADLINE) {
+  console.error("APPLICATION_DEADLINE is missing!");
 }
 
 console.log(`env: ${JSON.stringify(env, null, 2)}`);

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -22,4 +22,5 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 
+.env
 .eslintcache

--- a/frontend/src/pages/Apply.tsx
+++ b/frontend/src/pages/Apply.tsx
@@ -7,8 +7,11 @@ import { countWords } from "../util";
 const RESUME_UPLOAD_URL = "/api/resume";
 const SUBMIT_URL = "/api/application";
 
-const PRESIDENT_EMAIL = "bej001@ucsd.edu";
-const DEADLINE = new Date("2025-10-13T23:59:59-07:00"); // PDT is UTC-7
+if (!process.env.REACT_APP_APPLICATION_DEADLINE) {
+  throw new Error("Missing REACT_APP_APPLICATION_DEADLINE!");
+}
+
+const DEADLINE = new Date(process.env.REACT_APP_APPLICATION_DEADLINE);
 const HEAR_ABOUT_TSE_OPTIONS = [
   "Word of mouth",
   "Tabling on Library Walk",
@@ -547,8 +550,8 @@ function Apply() {
               You may apply to either TSE or the TEST program, but not both. Please apply to the
               TEST program if you believe it would be a good fit for you. Once you apply to the TEST
               program, we will not be able to consider you for general admission, and vice versa. If
-              you are unsure about which program is right for you, please contact TSE&apos;s current
-              president at <a href={`mailto:${PRESIDENT_EMAIL}`}>{PRESIDENT_EMAIL}</a>.
+              you are unsure about which program is right for you, please contact us at{" "}
+              <a href="mailto:tse@ucsd.edu">tse@ucsd.edu</a>.
             </p>
           </Form.Text>
         </Row>


### PR DESCRIPTION
A few assorted changes:
1. Automatically disable review assignment emails (the emails that reviewers get when they are assigned to review an application) 24 hours before the application deadline (24 is the default, it can be overridden by an environment variable). In the past, VP Tech would manually do this on the deadline (I think by setting `notifyReviewersWhenAssigned` to `false`  on each stage in the database but I'm not 100% sure). Automating this will make Fulcrum easier to maintain. Up to you @yxli001 if you want to change my approach since you'll be admining this year
2. Replace the president's email with tse@ucsd.edu on the application form, for the same reasons as in https://github.com/TritonSE/tritonse.github.io/pull/159
3. Migrate the application deadline to an environment variable so we don't have to change it in the code every year. It's `APPLICATION_DEADLINE` on the backend and `REACT_APP_APPLICATION_DEADLINE` on the frontend. I *think* we can just set both these variables in DigitalOcean and they will apply when the frontend is built, but will need to verify when we deploy.


I tested these changes by changing the deadline and ensuring assignment emails were vs. weren't sent automatically.