### PR TITLE
Pass REACT_APP_APPLICATION_DEADLINE to frontend build as Docker arg

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,10 @@ FROM node:16
 
 WORKDIR /app
 
+# Pass frontend environment variables into build
+ARG REACT_APP_APPLICATION_DEADLINE
+ENV REACT_APP_APPLICATION_DEADLINE=$REACT_APP_APPLICATION_DEADLINE
+
 ENV NODE_ENV=development
 COPY package*.json ./
 COPY backend/package*.json backend/


### PR DESCRIPTION
The [Fulcrum deployment](https://tse-fulcrum-2024-33w7u.ondigitalocean.app/) is broken now saying it's missing the `REACT_APP_APPLICATION_DEADLINE` environment variable. I added this env variable in the DigitalOcean console, re-deployed, and it's still missing.

I'm pretty sure we need to pass the env variable to the `npm run build` command in our Dockerfile. The [build logs](https://cloud.digitalocean.com/apps/535ba1df-3625-40f8-a188-8c794c66b336/deployments/ff25f9e5-b71e-401b-92bb-83e4b6bc8723?i=fb89b1) show that `REACT_APP_APPLICATION_DEADLINE` was in fact available to the Docker build command:

<img width="1243" height="546" alt="Screenshot from 2025-08-22 21-21-25" src="https://github.com/user-attachments/assets/d7b6b2ff-4f28-4a2a-953c-bea45cdc67ba" />
