### PR TITLE
Add isAdmin field to user model

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -17,6 +17,7 @@ async function onStartup() {
   const admin = await UserService.create({
     email: env.ADMIN_EMAIL,
     name: "Admin",
+    isAdmin: true,
   });
   if (admin !== null) {
     console.log("Created admin user");

--- a/backend/src/cakes.ts
+++ b/backend/src/cakes.ts
@@ -16,6 +16,7 @@ const CreateUserRequest = bake({
   onlyFirstYearTechnical: optional(boolean),
   isDoingInterviewAlone: optional(boolean),
   assignedStageIds: optional(array(number)),
+  isAdmin: optional(boolean),
 });
 
 type CreateUserRequest = Infer<typeof CreateUserRequest>;

--- a/backend/src/models/UserModel.ts
+++ b/backend/src/models/UserModel.ts
@@ -22,6 +22,8 @@ type User = {
 
   assignedStageIds: number[];
 
+  isAdmin: boolean;
+
   // TODO: add boolean for whether a user is active, and ensure that admin account is always active
 };
 
@@ -104,6 +106,12 @@ const UserSchema = new Schema<User>({
     type: [Number],
     required: true,
     default: [],
+  },
+
+  isAdmin: {
+    type: Boolean,
+    required: true,
+    default: false,
   },
 });
 

--- a/backend/src/services/UserService.ts
+++ b/backend/src/services/UserService.ts
@@ -25,6 +25,7 @@ class UserService {
     onlyFirstYearTechnical,
     isDoingInterviewAlone,
     assignedStageIds,
+    isAdmin,
   }: CreateUserRequest): Promise<UserDocument | null> {
     // TODO: To avoid race conditions, we should try to save, and catch the
     // exception if the user already exists (E11000).
@@ -40,6 +41,7 @@ class UserService {
       onlyFirstYearTechnical,
       isDoingInterviewAlone,
       assignedStageIds,
+      isAdmin,
     });
     return user.save();
   }


### PR DESCRIPTION
Add an `isAdmin` field to the user model for features that require role-checking. Defaults to `false`. 

Tested by running upsert-users script and making the field is set correctly. 