### PR TITLE
Confirmation prompt when connected to remote DB

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -21,6 +21,7 @@
         "morgan": "^1.10.0",
         "multer": "^1.4.5-lts.1",
         "nodemailer": "^6.7.8",
+        "readline-sync": "^1.4.10",
         "socket.io": "^4.7.2"
       },
       "devDependencies": {
@@ -33,6 +34,7 @@
         "@types/morgan": "^1.9.3",
         "@types/multer": "^1.4.12",
         "@types/nodemailer": "^6.4.5",
+        "@types/readline-sync": "^1.4.8",
         "@typescript-eslint/eslint-plugin": "^6.14.0",
         "@typescript-eslint/parser": "^6.14.0",
         "eslint": "^8.55.0",
@@ -1960,6 +1962,13 @@
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
       "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ=="
+    },
+    "node_modules/@types/readline-sync": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/@types/readline-sync/-/readline-sync-1.4.8.tgz",
+      "integrity": "sha512-BL7xOf0yKLA6baAX6MMOnYkoflUyj/c7y3pqMRfU0va7XlwHAOTOIo4x55P/qLfMsuaYdJJKubToLqRVmRtRZA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/request": {
       "version": "2.48.12",
@@ -6077,6 +6086,15 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/readline-sync": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/readline-sync/-/readline-sync-1.4.10.tgz",
+      "integrity": "sha512-gNva8/6UAe8QYepIQH/jQ2qn91Qj0B9sYjMBBs3QOB8F2CXcKgLxQaJRP76sWVRQt+QU+8fAkCbCvjjMFu7Ycw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/regexp.prototype.flags": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -22,6 +22,7 @@
     "@types/morgan": "^1.9.3",
     "@types/multer": "^1.4.12",
     "@types/nodemailer": "^6.4.5",
+    "@types/readline-sync": "^1.4.8",
     "@typescript-eslint/eslint-plugin": "^6.14.0",
     "@typescript-eslint/parser": "^6.14.0",
     "eslint": "^8.55.0",
@@ -47,6 +48,7 @@
     "morgan": "^1.10.0",
     "multer": "^1.4.5-lts.1",
     "nodemailer": "^6.7.8",
+    "readline-sync": "^1.4.10",
     "socket.io": "^4.7.2"
   }
 }

--- a/backend/src/env.ts
+++ b/backend/src/env.ts
@@ -1,4 +1,5 @@
 import dotenv from "dotenv";
+import readlineSync from "readline-sync";
 
 dotenv.config();
 
@@ -119,5 +120,16 @@ if (!env.APPLICATION_DEADLINE) {
 }
 
 console.log(`env: ${JSON.stringify(env, null, 2)}`);
+
+const isLocalDB = env.MONGODB_URL.includes("127.0.0.1") || env.MONGODB_URL.includes("localhost");
+if (!isLocalDB && env.NODE_ENV === "development") {
+  const response = readlineSync.question(
+    'WARNING: you are running Fulcrum locally, but connected to a remote DB. Please enter "y" to confirm: ',
+  );
+  if (response !== "y") {
+    console.log('No "y" received, exiting');
+    process.exit();
+  }
+}
 
 export default env;


### PR DESCRIPTION
Adds a confirmation prompt in the console when running Fulcrum in development mode but connected to a remote MongoDB database. This protects against running destructive operations when we changed our `.env` file to point to the production DB and accidentally forgot to change it back.

Uses `readline-sync` library to read user input. Does this once upon startup for either running the app or any script (any time `env.ts` is imported)