### PR TITLE
Allow review saves with incomplete fields

### DIFF
--- a/backend/src/config/stages.ts
+++ b/backend/src/config/stages.ts
@@ -18,7 +18,7 @@ const stageIdentifiers = [
 type StageIdentifier = (typeof stageIdentifiers)[number];
 
 type FormField = {
-  type: "string" | "number" | "boolean";
+  type: "string" | "number";
   choices: unknown[];
   allowOther: boolean;
   label: string;

--- a/backend/src/services/ReviewService.ts
+++ b/backend/src/services/ReviewService.ts
@@ -311,7 +311,13 @@ class ReviewService {
     }
 
     // If any of the stage's fields are not present on the review, then it's not complete
-    if (Object.keys(stage.fields).some((fieldName) => !review.fields[fieldName])) {
+    if (
+      Object.keys(stage.fields).some(
+        (fieldName) =>
+          (review.fields as unknown as Map<string, string | number | boolean>).get(fieldName) ===
+          undefined,
+      )
+    ) {
       return ReviewStatus.InProgress;
     }
     return ReviewStatus.Completed;

--- a/backend/src/services/ReviewService.ts
+++ b/backend/src/services/ReviewService.ts
@@ -16,6 +16,12 @@ import EmailService from "./EmailService";
 import StageService from "./StageService";
 import UserService from "./UserService";
 
+export enum ReviewStatus {
+  NotStarted = "notStarted",
+  InProgress = "inProgress",
+  Completed = "completed",
+}
+
 class ReviewService {
   async create(stage: Stage, application: Types.ObjectId): Promise<ReviewDocument> {
     const review = await new ReviewModel({
@@ -275,14 +281,40 @@ class ReviewService {
   }
 
   async getNextReviewForUser(userEmail: string): Promise<ReviewDocument | null> {
-    const result = await ReviewModel.findOne({
-      // Find a review with no fields filled in
+    // First, try to find a "Not Started" review (with no fields filled in)
+    let result = await ReviewModel.findOne({
       $expr: {
         $eq: [{ $size: { $objectToArray: "$fields" } }, 0],
       },
       reviewerEmail: userEmail,
     });
+
+    // If none are found, try to find an "In Progress" review
+    if (result === null) {
+      const reviewsForReviewer = await ReviewModel.find({ reviewerEmail: userEmail });
+      result =
+        reviewsForReviewer.find(
+          (review) => this.getReviewStatus(review) === ReviewStatus.InProgress,
+        ) ?? null;
+    }
+
     return result;
+  }
+
+  getReviewStatus(review: ReviewDocument) {
+    if (Object.keys(review.fields).length === 0) {
+      return ReviewStatus.NotStarted;
+    }
+    const stage = StageService.getById(review.stageId);
+    if (!stage) {
+      throw new Error(`Stage with ID ${review.stageId} not found`);
+    }
+
+    // If any of the stage's fields are not present on the review, then it's not complete
+    if (Object.keys(stage.fields).some((fieldName) => !review.fields[fieldName])) {
+      return ReviewStatus.InProgress;
+    }
+    return ReviewStatus.Completed;
   }
 
   /* 1 - First year, 2 - Second year... */

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -34,7 +34,7 @@ export type BulkAdvanceOrRejectResponse = Record<
 >;
 
 interface FormField {
-  type: "string" | "number" | "boolean";
+  type: "string" | "number";
   choices: (string | number | boolean)[];
   allowOther: boolean;
   label: string;

--- a/frontend/src/helpers/review.ts
+++ b/frontend/src/helpers/review.ts
@@ -1,0 +1,31 @@
+import { PopulatedReview } from "../api";
+
+export enum ReviewStatus {
+  NotStarted = "notStarted",
+  InProgress = "inProgress",
+  Completed = "completed",
+}
+
+export const getReviewStatus = (review: PopulatedReview) => {
+  if (Object.keys(review.fields).length === 0) {
+    return ReviewStatus.NotStarted;
+  }
+  // If any of the stage's fields are not present on the review, then it's not complete
+  if (Object.keys(review.stage.fields).some((fieldName) => !review.fields[fieldName])) {
+    return ReviewStatus.InProgress;
+  }
+  return ReviewStatus.Completed;
+};
+
+export const getReviewStatusHumanReadable = (review: PopulatedReview) => {
+  switch (getReviewStatus(review)) {
+    case ReviewStatus.NotStarted:
+      return "Not Started";
+    case ReviewStatus.InProgress:
+      return "In Progress";
+    case ReviewStatus.Completed:
+      return "Completed";
+    default:
+      return "Unknown";
+  }
+};

--- a/frontend/src/helpers/review.ts
+++ b/frontend/src/helpers/review.ts
@@ -11,7 +11,9 @@ export const getReviewStatus = (review: PopulatedReview) => {
     return ReviewStatus.NotStarted;
   }
   // If any of the stage's fields are not present on the review, then it's not complete
-  if (Object.keys(review.stage.fields).some((fieldName) => !review.fields[fieldName])) {
+  if (
+    Object.keys(review.stage.fields).some((fieldName) => review.fields[fieldName] === undefined)
+  ) {
     return ReviewStatus.InProgress;
   }
   return ReviewStatus.Completed;

--- a/frontend/src/pages/EditReview.tsx
+++ b/frontend/src/pages/EditReview.tsx
@@ -30,6 +30,14 @@ export function ReviewView({ id, showApplication }: { id: string; showApplicatio
       setField("fields", { ...getField("fields"), [fieldName]: value });
     }
   };
+  // Remove this field from the review object when the user erases it, so that we don't save a value
+  const clearReviewField = (fieldName: string) => {
+    if (review !== null) {
+      const fields = { ...getField("fields") };
+      delete fields[fieldName];
+      setField("fields", fields);
+    }
+  };
 
   useEffect(() => {
     api
@@ -104,23 +112,18 @@ export function ReviewView({ id, showApplication }: { id: string; showApplicatio
             const field = stage.fields[fieldName];
             let control;
             switch (field.type) {
-              case "boolean":
-                control = (
-                  <Form.Check
-                    type="checkbox"
-                    checked={!!getReviewField(fieldName)}
-                    onChange={(e) => setReviewField(fieldName, e.target.checked)}
-                    disabled={!editable}
-                  />
-                );
-                break;
               case "number":
                 control = (
                   <Form.Control
-                    required
                     type="number"
                     value={"" + getReviewField(fieldName)}
-                    onChange={(e) => setReviewField(fieldName, parseFloat(e.target.value))}
+                    onChange={(e) => {
+                      if (e.target.value === "") {
+                        clearReviewField(fieldName);
+                      } else {
+                        setReviewField(fieldName, parseFloat(e.target.value));
+                      }
+                    }}
                     onWheel={
                       // eslint-disable-next-line @typescript-eslint/no-explicit-any
                       (e) => (e.target as any).blur() /* https://stackoverflow.com/a/67432053 */
@@ -132,7 +135,6 @@ export function ReviewView({ id, showApplication }: { id: string; showApplicatio
               default:
                 control = editable ? (
                   <Form.Control
-                    required
                     as="textarea"
                     rows={10}
                     value={
@@ -140,7 +142,13 @@ export function ReviewView({ id, showApplication }: { id: string; showApplicatio
                         ? ""
                         : getReviewField(fieldName) + ""
                     }
-                    onChange={(e) => setReviewField(fieldName, e.target.value)}
+                    onChange={(e) => {
+                      if (e.target.value === "") {
+                        clearReviewField(fieldName);
+                      } else {
+                        setReviewField(fieldName, e.target.value);
+                      }
+                    }}
                   />
                 ) : (
                   <div style={{ whiteSpace: "pre-line" }}>

--- a/frontend/src/views/ReviewsView.tsx
+++ b/frontend/src/views/ReviewsView.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { Button, Form, Table } from "react-bootstrap";
 
 import api, { PopulatedReview } from "../api";
+import { getReviewStatus, getReviewStatusHumanReadable, ReviewStatus } from "../helpers/review";
 import { useAlerts } from "../hooks";
 import { formatQuarter, makeComparator } from "../util";
 
@@ -67,6 +68,13 @@ function ManualAssign({
   );
 }
 
+// Used to sort reviews by status
+const reviewStatusNumericValues = {
+  [ReviewStatus.NotStarted]: 0,
+  [ReviewStatus.InProgress]: 1,
+  [ReviewStatus.Completed]: 2,
+};
+
 export default function ReviewsView({
   filter,
   showReassign,
@@ -96,7 +104,7 @@ export default function ReviewsView({
               makeComparator((r) =>
                 homepage
                   ? [
-                      Object.entries(r.fields).length > 0 ? 1 : 0,
+                      reviewStatusNumericValues[getReviewStatus(r)],
                       r.stage.name,
                       r.application.gradQuarter,
                       r.application.name,
@@ -138,7 +146,7 @@ export default function ReviewsView({
           </thead>
           <tbody>
             {reviews.map((review) => {
-              const status = Object.keys(review.fields).length > 0 ? "complete" : "blank";
+              const status = getReviewStatusHumanReadable(review);
               const pastReviewers = Object.entries(
                 reviews
                   .filter((r) => review.application._id === r.application._id)

--- a/frontend/src/views/StageApplicationsView.tsx
+++ b/frontend/src/views/StageApplicationsView.tsx
@@ -9,6 +9,7 @@ import api, {
   Progress,
   Stage,
 } from "../api";
+import { getReviewStatus, ReviewStatus } from "../helpers/review";
 import { useAlerts } from "../hooks";
 import { makeComparator, formatQuarter } from "../util";
 
@@ -104,7 +105,8 @@ export default function StageApplicationsView({ stageId }: { stageId: number }) 
     grouped[appId][1].push(review);
   });
 
-  const isComplete = (review: PopulatedReview) => Object.keys(review.fields).length !== 0;
+  const isComplete = (review: PopulatedReview) =>
+    getReviewStatus(review) === ReviewStatus.Completed;
 
   let scoreKeys: string[] = [];
   reviews.filter(isComplete).forEach((review) => {


### PR DESCRIPTION
- Allow reviewers to save reviews with incomplete fields; only the fields they enter a score for will be saved on the `review.fields`
- Update logic for checking if a review is complete to consider 3 statuses: not started (no fields are filled in), in progress (some but not all fields are filled in), and completed (all fields are filled in), checking against the fields on the review's stage
- Your reviews table on homepage now displays status for each review, sorting by not started, then in progress, then completed
- Candidates by stage table now only shows scores & average score for complete reviews
- Updated next review endpoint to get a not started review, if any, falling back to an in progress review
- Removed support for boolean review fields because 1. we're not using them, and 2. it would be complicated to figure out if an unchecked checkbox means the field should be false, or just isn't filled in yet. We'd have to figure that out if we ever need boolean fields again in the future - maybe have a select menu with options for "Yes", "No", and "Please select a value" which indicates nothing selected

Tested these changes by clearing/setting review fields and checking the review status afterward

<img width="1848" height="197" alt="Screenshot from 2025-08-24 13-01-45" src="https://github.com/user-attachments/assets/9bb0c425-e85e-4dbc-bfc0-8df977feacce" />
