### PR TITLE
Add permission checks

### DIFF
--- a/backend/src/routes/application.ts
+++ b/backend/src/routes/application.ts
@@ -3,7 +3,7 @@ import { Router } from "express";
 import { Application } from "../models";
 import { ApplicationService } from "../services";
 
-import { authWrapper, wrapper } from "./wrappers";
+import { adminRequiredWrapper, authWrapper, wrapper } from "./wrappers";
 
 const router = Router();
 
@@ -23,7 +23,7 @@ router.get(
 
 router.delete(
   "/:applicationId",
-  authWrapper(async (_user, req) => {
+  adminRequiredWrapper(async (_user, req) => {
     const result = await ApplicationService.deleteById(req.params.applicationId);
     if (typeof result === "string") {
       return {

--- a/backend/src/routes/progress.ts
+++ b/backend/src/routes/progress.ts
@@ -4,7 +4,7 @@ import mongoose from "mongoose";
 import { BulkAdvanceOrRejectRequest } from "../cakes";
 import { ProgressService } from "../services";
 
-import { authWrapper } from "./wrappers";
+import { adminRequiredWrapper, authWrapper } from "./wrappers";
 
 const router = Router();
 
@@ -23,7 +23,7 @@ router.get(
 
 router.post(
   "/bulk_advance",
-  authWrapper(async (_user, req) => {
+  adminRequiredWrapper(async (_user, req) => {
     const bodyResult = BulkAdvanceOrRejectRequest.check(req.body);
     if (!bodyResult.ok) {
       return {
@@ -59,7 +59,7 @@ router.post(
 
 router.post(
   "/bulk_reject",
-  authWrapper(async (_user, req) => {
+  adminRequiredWrapper(async (_user, req) => {
     const bodyResult = BulkAdvanceOrRejectRequest.check(req.body);
     if (!bodyResult.ok) {
       return {

--- a/backend/src/routes/user.ts
+++ b/backend/src/routes/user.ts
@@ -3,7 +3,7 @@ import { Router } from "express";
 import { CreateUserRequest } from "../cakes";
 import { UserService } from "../services";
 
-import { authWrapper } from "./wrappers";
+import { adminRequiredWrapper, authWrapper } from "./wrappers";
 
 const router = Router();
 
@@ -20,7 +20,7 @@ router.get(
 
 router.post(
   "/",
-  authWrapper(async (_user, req) => {
+  adminRequiredWrapper(async (_user, req) => {
     const bodyResult = CreateUserRequest.check(req.body);
     if (!bodyResult.ok) {
       return {

--- a/backend/src/routes/wrappers.ts
+++ b/backend/src/routes/wrappers.ts
@@ -64,4 +64,14 @@ function authWrapper(handler: AsyncAuthHandler): RequestHandler {
   });
 }
 
-export { wrapper, getUser, authWrapper };
+// A wrapper to use around routes that require the user to be an admin
+function adminRequiredWrapper(handler: AsyncAuthHandler): RequestHandler {
+  return authWrapper((user, req, res) => {
+    if (!user.isAdmin) {
+      return { status: 403, text: "You must be an admin to perform this action" };
+    }
+    return handler(user, req, res);
+  });
+}
+
+export { wrapper, getUser, authWrapper, adminRequiredWrapper };

--- a/backend/src/services/ReviewService.ts
+++ b/backend/src/services/ReviewService.ts
@@ -78,10 +78,6 @@ class ReviewService {
       return "Review not found";
     }
 
-    if (review.reviewerEmail !== currentReviewerEmail) {
-      return "Review not assigned to user";
-    }
-
     const applicationDoc = await ApplicationService.getById(review.application);
     if (!applicationDoc) {
       return "Application not found";

--- a/backend/src/services/UserService.ts
+++ b/backend/src/services/UserService.ts
@@ -10,6 +10,7 @@ import EmailService from "./EmailService";
 type PublicUser = {
   email: string;
   name: string;
+  isAdmin: boolean;
 };
 
 type LogInResponse = {
@@ -161,6 +162,7 @@ class UserService {
     return {
       email: user.email,
       name: user.name,
+      isAdmin: user.isAdmin,
     };
   }
 

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -3,6 +3,7 @@ type Method = "get" | "post" | "put";
 export interface User {
   email: string;
   name: string;
+  isAdmin: boolean;
 }
 
 interface LogInRequest {

--- a/frontend/src/pages/EditReview.tsx
+++ b/frontend/src/pages/EditReview.tsx
@@ -20,7 +20,7 @@ export function ReviewView({ id, showApplication }: { id: string; showApplicatio
   const [showConfirmReassignModal, setShowConfirmReassignModal] = useState(false);
 
   const editable = useMemo(
-    () => !!(user && review && user.email === review.reviewerEmail),
+    () => !!(user && review && (user.isAdmin || user.email === review.reviewerEmail)),
     [user, review]
   );
 
@@ -78,9 +78,15 @@ export function ReviewView({ id, showApplication }: { id: string; showApplicatio
       {showApplication && (
         <>
           <h2>Application</h2>
-          <Button type="button" variant="danger" onClick={() => setShowConfirmReassignModal(true)}>
-            Reassign
-          </Button>
+          {editable ? (
+            <Button
+              type="button"
+              variant="danger"
+              onClick={() => setShowConfirmReassignModal(true)}
+            >
+              Reassign
+            </Button>
+          ) : null}
           {review && <ApplicationView id={review.application} />}
         </>
       )}


### PR DESCRIPTION
- Added `isAdmin` to the `/api/auth/me` response
- Add a new `adminRequiredWrapper` helper function which ensures a route is only accessible to admins (returns HTTP 403 to non-admins)
- Adds admin-only permission check to the following API routes (note: we are definitely going to remove 4 & 5, and may also remove 2, but just implementing permission checks now so all destructive routes are secure):
    1. Bulk advance/reject
    2. Auto-assign review
    3. Manual re-assign review
    4. Create user 
    5. Delete application
- Add a permission check to the edit review and reassign (i.e. request reassignment of one of your own reviews) endpoints to require the user to either be an admin, or be the reviewer assigned to that review
- On the review page, show the "reassign" button and allow the user to edit a review only if they are an admin or the assigned reviewer

Tested these changes by logging in as admin vs. non-admin and assigned vs. not assigned reviewer and ensuring actions are appropriately allowed/disallowed:

<img width="555" height="157" alt="Screenshot from 2025-08-24 13-55-12" src="https://github.com/user-attachments/assets/ce56b5df-993a-4579-8ab9-10e47f310d76" />
<img width="1172" height="428" alt="Screenshot from 2025-08-24 13-54-10" src="https://github.com/user-attachments/assets/4c40b47f-0e19-4ff3-937f-c887e2455202" />
<img width="689" height="329" alt="Screenshot from 2025-08-24 13-53-36" src="https://github.com/user-attachments/assets/3a961e02-dd93-407e-9447-39d6d281ef20" />
<img width="689" height="329" alt="Screenshot from 2025-08-24 13-32-02" src="https://github.com/user-attachments/assets/42ff3c81-ad6e-4df7-b23a-13c0f49223e4" />

