### PR TITLE
Fix input value for Fall quarter

### DIFF
--- a/frontend/src/pages/Apply.tsx
+++ b/frontend/src/pages/Apply.tsx
@@ -364,7 +364,7 @@ function Apply() {
                 <option value="1">Spring</option>
                 {/* Hide summer because people often select summer when they mean spring. */}
                 {/* <option value="2">Summer</option> */}
-                <option value="3">Fall</option>
+                <option value="2">Fall</option>
               </Form.Select>
             </Form.Group>
           </Col>


### PR DESCRIPTION
<img width="1919" height="44" alt="image" src="https://github.com/user-attachments/assets/ea43a687-11c5-47e8-ad21-13ef26711821" />

Shown above, ending quarter (Fall) was displaying incorrectly because I forgot to change the ending quarter input on the application form to have the updated value for Fall. 
