### PR TITLE
Fix interview & logo styling

### DIFF
--- a/frontend/src/components/TSELogo.tsx
+++ b/frontend/src/components/TSELogo.tsx
@@ -1,0 +1,29 @@
+import { ReactNode } from "react";
+
+interface TSELogoProps {
+  msg: string;
+  children?: ReactNode;
+}
+
+/**
+ * Displays the TSE lightbulb logo along with text and content below it
+ */
+function TSELogo({ msg, children }: TSELogoProps) {
+  return (
+    <div className="tw:flex tw:items-center tw:justify-center tw:min-h-screen tw:bg-teal-primary tw:text-cream-primary">
+      <div className="tw:min-w-[320px] tw:flex tw:flex-col tw:gap-2">
+        <h1 className="tw:flex tw:flex-col tw:items-center tw:gap-3">
+          <img width="64" height="64" src="/logo512.png" alt="TSE logo" />
+          {msg}
+        </h1>
+        {children ?? null}
+      </div>
+    </div>
+  );
+}
+
+TSELogo.defaultProps = {
+  children: undefined,
+};
+
+export default TSELogo;

--- a/frontend/src/pages/Interview.tsx
+++ b/frontend/src/pages/Interview.tsx
@@ -10,6 +10,8 @@ import cpp from "react-syntax-highlighter/dist/esm/languages/prism/cpp";
 import { dark } from "react-syntax-highlighter/dist/esm/styles/prism";
 import { io, type Socket } from "socket.io-client";
 
+import TSELogo from "../components/TSELogo";
+
 SyntaxHighlighter.registerLanguage("cpp", cpp);
 
 const LANGS = ["python", "javascript", "java", "cpp", "text"];
@@ -66,10 +68,6 @@ interface CodeProps {
   className?: string;
 }
 
-interface LoadingProps {
-  msg: string;
-}
-
 interface TimerProps {
   role: number;
   since: number;
@@ -104,28 +102,6 @@ function MarkdownImage({
   width,
 }: React.ClassAttributes<HTMLImageElement> & React.ImgHTMLAttributes<HTMLImageElement>) {
   return <img src={src?.replace("&amp;", "&")} alt={alt} height={height} width={width} />;
-}
-
-function LoadingScreen({ msg }: LoadingProps) {
-  return (
-    <div
-      style={{
-        display: "flex",
-        alignItems: "center",
-        justifyContent: "center",
-        height: "100vh",
-        textAlign: "center",
-        background: "#0c2a34",
-        color: "white",
-      }}
-    >
-      <div>
-        <img width="64" height="64" src="/logo512.png" alt="TSE logo" />
-        <br />
-        <h1>{msg}</h1>
-      </div>
-    </div>
-  );
 }
 
 function Timer({ role, since, start }: TimerProps) {
@@ -385,7 +361,7 @@ export default function Interview() {
   }, [selectFrom, selectTo]);
 
   if (!socket) {
-    return <LoadingScreen msg="Connecting..." />;
+    return <TSELogo msg="Connecting..." />;
   }
 
   return (
@@ -504,7 +480,7 @@ export default function Interview() {
           />
         </div>
       )}
-      {role === INTERVIEWEE && !active && <LoadingScreen msg="Please wait for your interviewer." />}
+      {role === INTERVIEWEE && !active && <TSELogo msg="Please wait for your interviewer." />}
       {active && (
         <Timer
           role={role}

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -3,6 +3,7 @@ import { Button, Form } from "react-bootstrap";
 import { useNavigate } from "react-router-dom";
 
 import api from "../api";
+import TSELogo from "../components/TSELogo";
 import { GlobalContext } from "../context/GlobalContext";
 import { useAlerts } from "../hooks";
 
@@ -46,33 +47,27 @@ export default function Login() {
   };
 
   return (
-    <div className="tw:flex tw:items-center tw:justify-center tw:min-h-screen tw:bg-teal-primary tw:text-cream-primary">
-      <div className="tw:min-w-[320px] tw:flex tw:flex-col tw:gap-2">
-        <h1 className="tw:flex tw:flex-col tw:items-center tw:gap-3">
-          <img width="64" height="64" src="/logo512.png" alt="TSE logo" />
-          TSE Fulcrum
-        </h1>
-        <Form onSubmit={onSubmit}>
-          <Form.Group controlId="email">
-            <Form.Label>Email address</Form.Label>
-            <Form.Control type="email" onChange={(e) => setField("email", e.target.value)} />
-          </Form.Group>
-          <br />
-          <Form.Group controlId="password">
-            <Form.Label>Password</Form.Label>
-            <Form.Control type="password" onChange={(e) => setField("password", e.target.value)} />
-          </Form.Group>
-          <br />
-          <div className="tw:flex tw:justify-around tw:gap-4">
-            <Button type="submit">Log in</Button>
-            <Button variant="secondary" onClick={onForgotPassword}>
-              Forgot password
-            </Button>
-          </div>
-          <br />
-          {alerts}
-        </Form>
-      </div>
-    </div>
+    <TSELogo msg="TSE Fulcrum">
+      <Form onSubmit={onSubmit}>
+        <Form.Group controlId="email">
+          <Form.Label>Email address</Form.Label>
+          <Form.Control type="email" onChange={(e) => setField("email", e.target.value)} />
+        </Form.Group>
+        <br />
+        <Form.Group controlId="password">
+          <Form.Label>Password</Form.Label>
+          <Form.Control type="password" onChange={(e) => setField("password", e.target.value)} />
+        </Form.Group>
+        <br />
+        <div className="tw:flex tw:justify-around tw:gap-4">
+          <Button type="submit">Log in</Button>
+          <Button variant="secondary" onClick={onForgotPassword}>
+            Forgot password
+          </Button>
+        </div>
+        <br />
+        {alerts}
+      </Form>
+    </TSELogo>
   );
 }

--- a/frontend/src/pages/RequestPasswordReset.tsx
+++ b/frontend/src/pages/RequestPasswordReset.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from "react";
 import { Button, Form } from "react-bootstrap";
 
 import api from "../api";
+import TSELogo from "../components/TSELogo";
 import { useAlerts } from "../hooks";
 
 export default function RequestPasswordReset() {
@@ -27,23 +28,17 @@ export default function RequestPasswordReset() {
   };
 
   return (
-    <div className="tw:flex tw:items-center tw:justify-center tw:min-h-screen tw:bg-teal-primary tw:text-cream-primary">
-      <div className="tw:w-[320px] tw:flex tw:flex-col tw:items-center">
-        <h1 className="tw:text-center tw:w-[200px] tw:mx-auto tw:mb-2 tw:flex tw:flex-col tw:items-center tw:gap-2">
-          <img width="64" height="64" src="/logo512.png" alt="TSE logo" />
-          Request Password Reset
-        </h1>
-        <Form onSubmit={onSubmit} className="tw:flex tw:flex-col tw:gap-5 tw:w-full">
-          <Form.Group controlId="email">
-            <Form.Label>Email address</Form.Label>
-            <Form.Control type="email" onChange={(e) => setEmail(e.target.value)} />
-          </Form.Group>
-          <div className="tw:flex tw:justify-center">
-            <Button type="submit">Request password reset</Button>
-          </div>
-          {alerts}
-        </Form>
-      </div>
-    </div>
+    <TSELogo msg="Request Password Reset">
+      <Form onSubmit={onSubmit} className="tw:flex tw:flex-col tw:gap-5 tw:w-full">
+        <Form.Group controlId="email">
+          <Form.Label>Email address</Form.Label>
+          <Form.Control type="email" onChange={(e) => setEmail(e.target.value)} />
+        </Form.Group>
+        <div className="tw:flex tw:justify-center">
+          <Button type="submit">Request password reset</Button>
+        </div>
+        {alerts}
+      </Form>
+    </TSELogo>
   );
 }

--- a/frontend/src/pages/ResetPassword.tsx
+++ b/frontend/src/pages/ResetPassword.tsx
@@ -3,6 +3,7 @@ import { Button, Form } from "react-bootstrap";
 import { useLocation, useNavigate } from "react-router-dom";
 
 import api from "../api";
+import TSELogo from "../components/TSELogo";
 import { useAlerts } from "../hooks";
 
 export default function ResetPassword() {
@@ -54,48 +55,32 @@ export default function ResetPassword() {
   };
 
   return (
-    <div
-      style={{
-        display: "flex",
-        alignItems: "center",
-        justifyContent: "center",
-        minHeight: "100vh",
-        background: "#0c2a34",
-        color: "white",
-      }}
-    >
-      <div style={{ minWidth: "320px" }}>
-        <h1 style={{ textAlign: "center" }}>
-          <img width="64" height="64" src="/logo512.png" alt="TSE logo" />
-          <br />
-          Reset Password
-        </h1>
-        <Form onSubmit={onSubmit}>
-          <Form.Group controlId="email">
-            <Form.Label>Email address</Form.Label>
-            <Form.Control type="email" onChange={(e) => setField("email", e.target.value)} />
-          </Form.Group>
-          <Form.Group controlId="password">
-            <Form.Label>Password</Form.Label>
-            <Form.Control type="password" onChange={(e) => setField("password", e.target.value)} />
-          </Form.Group>
-          <Form.Group controlId="confirm-password">
-            <Form.Label>Confirm password</Form.Label>
-            <Form.Control type="password" onChange={(e) => setConfirmPassword(e.target.value)} />
-          </Form.Group>
-          <br />
-          <div
-            style={{
-              display: "flex",
-              justifyContent: "center",
-            }}
-          >
-            <Button type="submit">Reset password</Button>
-          </div>
-          <br />
-          {alerts}
-        </Form>
-      </div>
-    </div>
+    <TSELogo msg="Reset Password">
+      <Form onSubmit={onSubmit}>
+        <Form.Group controlId="email">
+          <Form.Label>Email address</Form.Label>
+          <Form.Control type="email" onChange={(e) => setField("email", e.target.value)} />
+        </Form.Group>
+        <Form.Group controlId="password">
+          <Form.Label>Password</Form.Label>
+          <Form.Control type="password" onChange={(e) => setField("password", e.target.value)} />
+        </Form.Group>
+        <Form.Group controlId="confirm-password">
+          <Form.Label>Confirm password</Form.Label>
+          <Form.Control type="password" onChange={(e) => setConfirmPassword(e.target.value)} />
+        </Form.Group>
+        <br />
+        <div
+          style={{
+            display: "flex",
+            justifyContent: "center",
+          }}
+        >
+          <Button type="submit">Reset password</Button>
+        </div>
+        <br />
+        {alerts}
+      </Form>
+    </TSELogo>
   );
 }

--- a/frontend/vite.config.mjs
+++ b/frontend/vite.config.mjs
@@ -15,6 +15,11 @@ export default defineConfig({
         changeOrigin: true,
         secure: false,
       },
+      "/socket.io": {
+        target: "http://localhost:8000",
+        changeOrigin: true,
+        secure: false,
+      },
     },
   },
 });


### PR DESCRIPTION
1. Adds proxy for `/socket.io` paths to backend in local Vite development, since the interview socket.io connection wasn't working when these requests were going to the frontend
2. Create common `TSELogo` component to display the TSE logo with text and content below, like we have on the login, reset password, request password reset, and interview loading pages. This removes duplication and fixes the logo not being centered on some pages.

Before:

<img width="1850" height="1008" alt="Screenshot from 2025-09-01 19-39-53" src="https://github.com/user-attachments/assets/d659430a-4cbd-48f7-95ac-f161687e2ada" />
<img width="687" height="730" alt="Screenshot from 2025-09-01 19-39-43" src="https://github.com/user-attachments/assets/a3c85856-385d-4b37-8108-2a1971268d1e" />

After:

<img width="1850" height="1008" alt="Screenshot from 2025-09-01 19-51-58" src="https://github.com/user-attachments/assets/9aa4ce7a-d7bb-4c23-af01-3c37e35a195a" />
<img width="1850" height="1008" alt="Screenshot from 2025-09-01 19-50-05" src="https://github.com/user-attachments/assets/0b5f0bcc-ccea-408d-ac68-58cb6c7e0d52" />
<img width="1850" height="1008" alt="Screenshot from 2025-09-01 19-50-00" src="https://github.com/user-attachments/assets/8677d2b2-fbb4-4640-99af-6443f6a0c745" />
