### PR TITLE
Small backend deployment fix

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "scripts": {
     "build": "tsc",
-    "start": "node dist/app.js",
+    "start": "node dist/src/app.js",
     "dev": "nodemon --watch src --ext ts --exec ts-node src/app.ts",
     "test": "jest",
     "upsert-users": "ts-node src/scripts/upsertUsers.ts",


### PR DESCRIPTION
The deployment is failing with this error after merging #28:

<img width="1213" height="789" alt="Screenshot from 2025-09-18 13-21-17" src="https://github.com/user-attachments/assets/4cadfc86-5862-4835-bae0-16f5d9a335dd" />

I think this is because I changed `backend/tsconfig.json` to allow the `tests` directory to import from `src`, and that causes all built files to go into `dist/src` instead of just `dist`.

So I fixed the backend start command and tested it locally to ensure it works now.
