### PR TITLE
Fix static files path

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -49,12 +49,14 @@ async function main() {
 
   app.use("/api", routes);
 
+  const staticRoot = path.join(__dirname, "../../public/");
+
   // Serve static files.
-  app.use(express.static(path.join(__dirname, "../public/")));
+  app.use(express.static(staticRoot));
 
   // Serve index.html for routes that don't match files, to enable client-side routing.
   app.get("*", (_, res) => {
-    res.sendFile("index.html", { root: path.join(__dirname, "../public/") });
+    res.sendFile("index.html", { root: staticRoot });
   });
 
   const server = http.createServer(app);


### PR DESCRIPTION
Following up on #29, Fulcrum is now returning a 404 for all frontend paths. This is because the backend uses a relative path to find the `public` directory from the current file. Since backend files are now in `dist/src` instead of just `dist`, we need to go one additional level up in order to get to the static files.

Note that we don't actually use the static file serving from the backend for local development, we just run separate dev servers for frontend & backend, so this doesn't break anything (I double-checked that `npm run dev` and `npm run build` followed by `npm start` both work now) 