### PR TITLE
Add support for specific reviewers doing fewer reviews

### DIFF
--- a/backend/jest.config.cjs
+++ b/backend/jest.config.cjs
@@ -4,6 +4,7 @@ module.exports = {
     "^.*\\.tsx?$": "ts-jest",
   },
   testRegex: "^.*\\.test\\.(jsx?|tsx?)$",
+  testPathIgnorePatterns: ["/node_modules", "<rootDir>/dist/"],
   moduleFileExtensions: ["ts", "tsx", "js", "jsx", "json", "node"],
   moduleNameMapper: {
     "^src/(.*)": "<rootDir>/src/$1",

--- a/backend/src/cakes.ts
+++ b/backend/src/cakes.ts
@@ -1,4 +1,4 @@
-import { Infer, array, bake, boolean, number, optional, string, union } from "caketype";
+import { Infer, any, array, bake, boolean, number, optional, string, union } from "caketype";
 
 import { pipelineIdentifiers } from "./config";
 
@@ -16,6 +16,8 @@ const CreateUserRequest = bake({
   onlyFirstYearTechnical: optional(boolean),
   isDoingInterviewAlone: optional(boolean),
   assignedStageIds: optional(array(number)),
+  // TODO: add support for arbitrary-key record fields to caketype
+  maxReviewsPerStageIdentifier: optional(any),
   isAdmin: optional(boolean),
 });
 

--- a/backend/src/models/ApplicationModel.ts
+++ b/backend/src/models/ApplicationModel.ts
@@ -28,7 +28,7 @@ type Application = {
   testBarriersPrompt: string;
 
   // Map role identifiers to the corresponding prompts.
-  rolePrompts: Record<string, string>;
+  rolePrompts: Map<string, string>;
 
   blockListedReviewerEmails: string[];
 };

--- a/backend/src/models/ReviewModel.ts
+++ b/backend/src/models/ReviewModel.ts
@@ -8,7 +8,7 @@ type Review = {
   application: Types.ObjectId;
   interview?: Types.ObjectId;
   reviewerEmail?: string;
-  fields: Record<string, string | number | boolean>;
+  fields: Map<string, string | number | boolean>;
 };
 
 type RawReview = ObjectIdsToStrings<Review>;

--- a/backend/src/models/UserModel.ts
+++ b/backend/src/models/UserModel.ts
@@ -2,6 +2,8 @@ import { HydratedDocument, Schema, model } from "mongoose";
 
 import CryptoService from "../services/CryptoService";
 
+import { StageIdentifier } from "src/config";
+
 type User = {
   email: string;
   name: string;
@@ -21,6 +23,14 @@ type User = {
   isDoingInterviewAlone: boolean;
 
   assignedStageIds: number[];
+
+  // Optionally set maximum number of reviews on certain stages. This way,
+  // volunteers/alumni can help with recruitment but with a lower time commitment
+  // For technical interviews, this field's value is the TOTAL number of interviews
+  // this reviewer would do among them and their interview buddy (if any); we don't
+  // actually store interview buddies in the database, so we would just give them half
+  // this many reviews (e.g. if their max is 4 and they're not interviewing alone, give them 2)
+  maxReviewsPerStageIdentifier: Map<StageIdentifier, number>;
 
   isAdmin: boolean;
 
@@ -106,6 +116,11 @@ const UserSchema = new Schema<User>({
     type: [Number],
     required: true,
     default: [],
+  },
+  maxReviewsPerStageIdentifier: {
+    type: Map,
+    required: true,
+    default: {},
   },
 
   isAdmin: {

--- a/backend/src/services/UserService.ts
+++ b/backend/src/services/UserService.ts
@@ -27,6 +27,7 @@ class UserService {
     onlyFirstYearTechnical,
     isDoingInterviewAlone,
     assignedStageIds,
+    maxReviewsPerStageIdentifier,
     isAdmin,
   }: CreateUserRequest): Promise<UserDocument | null> {
     // TODO: To avoid race conditions, we should try to save, and catch the
@@ -43,6 +44,7 @@ class UserService {
       onlyFirstYearTechnical,
       isDoingInterviewAlone,
       assignedStageIds,
+      maxReviewsPerStageIdentifier: maxReviewsPerStageIdentifier as Record<string, number>,
       isAdmin,
     });
     return user.save();


### PR DESCRIPTION
Often, TSE alumni ask if they can help with the recruitment process,  but may want to do fewer reviews/interviews than normal, in order to have a lighter commitment. This PR:
- Adds support for such requests by adding a `maxReviewsPerStageIdentifier` field to the user model which stores a map of stage identifiers to maximum review counts for that stage (e.g. `"developer_resume_review": 5` would ensure the user is only assigned at most 5 dev resume reviews)
- Adds new unit tests for this functionality - I ensured these tests and the existing tests all pass, and I also manually tested the application form and advancing/rejecting/assignment flows locally to ensure I didn't break them
- Ensures that Jest won't try to run the backend tests in the `dist` folder, which would contain the compiled backend code if you've run `npm run build`, by adding `dist` to the ignore patterns

This feature could also be useful in the future if VP Eng/Design or TEST dev/design leads want to do both normal and TEST dev/designer reviews but be assigned fewer of each!