### PR TITLE
Fix "Next Review" button not triggering a rerender

### DIFF
--- a/frontend/src/pages/EditReview.tsx
+++ b/frontend/src/pages/EditReview.tsx
@@ -289,5 +289,5 @@ export function ReviewView({ id, showApplication }: { id: string; showApplicatio
 
 export default function EditReview() {
   const { reviewId } = useParams();
-  return <ReviewView id={reviewId || ""} showApplication />;
+  return <ReviewView key={reviewId} id={reviewId || ""} showApplication />;
 }


### PR DESCRIPTION
Since the "Next Review" links to the same route just with a different route parameter, it doesn't trigger a full page rerender by default, causing the candidate information on the page to not be updated correctly.

Added a `key` prop to the ReviewView component so that each time the `reviewId` route parameter changes the page guarantees a rerender. 