### PR TITLE
Fix bug on reviews page grouping

### DIFF
--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -27,6 +27,8 @@ export default function Home() {
           makeComparator((r) => [
             // Sort from latest to earliest pipelineIndex so we get most recent stage first
             -r.stage.pipelineIndex,
+            // Then by pipeline because some users review multiple pipelines (e.g. designer & TEST designer)
+            r.stage.pipelineIdentifier,
             reviewStatusNumericValues[getReviewStatus(r)],
             r.application.gradQuarter,
             r.application.name,


### PR DESCRIPTION
Nancy was seeing several groups of Designer Resume Reviews and TEST Designer Resume Reviews since she's reviewing both. This was due to a bug where these reviews are not ordered separately. This PR fixes that bug