### PR TITLE
Show navbar to all users and add UI indicators for when actions can't be performed by user

### DIFF
--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -89,32 +89,30 @@ function Navbar() {
       </Link>
 
       {/* Navigation links by pipeline and stage */}
-      {user?.isAdmin && (
-        <div className="tw:flex-1 tw:flex tw:flex-col tw:!text-sm tw:font-light">
-          <div className="tw:flex tw:flex-col tw:gap-1">
-            <NavLink to="/">My Reviews</NavLink>
-            <NavLink to="/reviews">
-              <span>All Applicants</span>
-            </NavLink>
-          </div>
-          {pipelines.map((pipeline) => (
-            <div key={pipeline.identifier} className="tw:flex tw:flex-col">
-              {/* Separator */}
-              <div className="tw:w-[90%] tw:h-[1px] tw:bg-cream-primary/30 tw:mx-auto tw:my-2" />
-              <h2 className="tw:text-cream-primary tw:!text-sm tw:font-bold tw:uppercase tw:!m-0 tw:px-2 tw:py-1">
-                {pipeline.name}
-              </h2>
-              <div className="tw:flex tw:flex-col tw:gap-1 tw:ml-2">
-                {stagesByPipeline[pipeline.name]?.map((stage) => (
-                  <NavLink key={stage.id} to={`/stage/${stage.id}/applications`}>
-                    {stage.name}
-                  </NavLink>
-                ))}
-              </div>
-            </div>
-          ))}
+      <div className="tw:flex-1 tw:flex tw:flex-col tw:!text-sm tw:font-light">
+        <div className="tw:flex tw:flex-col tw:gap-1">
+          <NavLink to="/">My Reviews</NavLink>
+          <NavLink to="/reviews">
+            <span>All Applicants</span>
+          </NavLink>
         </div>
-      )}
+        {pipelines.map((pipeline) => (
+          <div key={pipeline.identifier} className="tw:flex tw:flex-col">
+            {/* Separator */}
+            <div className="tw:w-[90%] tw:h-[1px] tw:bg-cream-primary/30 tw:mx-auto tw:my-2" />
+            <h2 className="tw:text-cream-primary tw:!text-sm tw:font-bold tw:uppercase tw:!m-0 tw:px-2 tw:py-1">
+              {pipeline.name}
+            </h2>
+            <div className="tw:flex tw:flex-col tw:gap-1 tw:ml-2">
+              {stagesByPipeline[pipeline.name]?.map((stage) => (
+                <NavLink key={stage.id} to={`/stage/${stage.id}/applications`}>
+                  {stage.name}
+                </NavLink>
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
 
       {/* Profile */}
       <div className="tw:flex tw:flex-col tw:items-center tw:gap-3 tw:mt-auto">

--- a/frontend/src/pages/EditReview.tsx
+++ b/frontend/src/pages/EditReview.tsx
@@ -118,6 +118,11 @@ export function ReviewView({ id, showApplication }: { id: string; showApplicatio
           CAREFUL: You are editing a review NOT assigned to you.
         </Alert>
       )}
+      {!ownsReview && !editable && (
+        <Alert variant="info" className="tw:w-full">
+          READ ONLY: You are viewing a review assigned to {review?.reviewerEmail}.
+        </Alert>
+      )}
       {showApplication && review && (
         <ApplicationHeader
           applicationId={review.application}


### PR DESCRIPTION
## Changes
- Navbar visible to all users
- Non-admin user viewing someone else's review sees "READ ONLY" message, and input fields are disabled
- Non-admin user viewing all applicants by stage sees "Only admins can advance or reject applicants" message, and all actions are disabled

## Screenshots
Non-admin user viewing someone else's review
<img width="1461" height="1222" alt="image" src="https://github.com/user-attachments/assets/ea5eb21c-dcc4-45c2-8e88-e7cbc77a64f6" />

Non-admin user viewing all applicants by stage
<img width="1490" height="508" alt="image" src="https://github.com/user-attachments/assets/43e39040-10b1-4de2-8602-c699fcd5db9c" />